### PR TITLE
:rocket: Dockerized this app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:latest
+
+ENV URLS="https://ma.rkus.io,https://www.uberswe.com" \
+    INTERVAL=60
+
+WORKDIR /usr/src/app
+
+COPY ./cmd/uptime/ .
+
+ENTRYPOINT go run ./main.go -interval=${INTERVAL} -urls=${URLS}


### PR DESCRIPTION
Run application using docker.

1. Build application by running : `docker build -t uptime .`
2. Run container by running : `docker run --name uptime -e URLS="https://zerka.dev" -e INTERVAL=60 uptime`
We can run it in detach mod using `-d`

Note: This containers hasn't publish in github docker registry, we can do it